### PR TITLE
Create action robust to repos not using renv

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -41,7 +41,7 @@ jobs:
           install.packages("renv")
           install.packages("rmarkdown")
           install.packages("yaml")
-          install.packages(renv::dependencies()$Packages)
+          install.packages(renv::dependencies()$Package)
         shell: Rscript {0}
 
       - name: Render and Publish

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -39,6 +39,8 @@ jobs:
         if: ${{ hashFiles('renv.lock') == ''}}
         run: |
           install.packages("renv")
+          install.packages("rmarkdown")
+          install.packages("yaml")
           install.packages(renv::dependencies()$Packages)
         shell: Rscript {0}
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,6 +35,13 @@ jobs:
         if: ${{ hashFiles('renv.lock') == ''}}
         uses: r-lib/actions/setup-r@v2
 
+      - name: Install R latest dependencies
+        if: ${{ hashFiles('renv.lock') == ''}}
+        run: |
+          install.packages("renv")
+          install.packages(renv::dependencies()$Packages)
+        shell: Rscript {0}
+
       - name: Render and Publish
         uses: quarto-dev/quarto-actions/publish@v2
         with:

--- a/TOPIC1/page1.qmd
+++ b/TOPIC1/page1.qmd
@@ -20,3 +20,9 @@ The headers below cause the table of contents/dropdown on the right to be visibl
 # Level One Again
 
 ## Level Two
+
+
+```{r}
+library(ggplot2)
+```
+


### PR DESCRIPTION
The GitHub Action will install the latest version of R and the latest version of detected package dependencies even if {renv} is not used in the project