### PR TITLE
Add ror options to CITATION file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,9 +4,17 @@ authors:
 - family-names: "YOUR_NAME_HERE"
   given-names: "YOUR_NAME_HERE"
   orcid: "https://orcid.org/0000-0000-0000-0000"
+  affiliation:
+    - name: LMU Open Science Center
+      ror: https://ror.org/029e6qe04
 - family-names: "Lisa"
   given-names: "Mona"
   orcid: "https://orcid.org/0000-0000-0000-0000"
+  affiliation:
+    - name: LMU Open Science Center
+      ror: https://ror.org/029e6qe04
+- name: LMU Open Science Center
+  ror: https://ror.org/029e6qe04
 title: ""
 version: 0.0.1
 doi: 


### PR DESCRIPTION
Felix and Florian, I think you two might have useful input on this topic.

In the CITATION file that will be used for all of our tutorials, I can include the [LMU Open Science Center's ROR ID](https://ror.org/029e6qe04) either by having authors include the OSC as an affiliation under themselves (see lines 7-9 and 13-15) or by including the OSC as an author of every tutorial (see lines 16-17). I'm not exactly sure what the correct approach here should be (or if there even is one). Thoughts?